### PR TITLE
add Signer signature to signTypedData

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -2,7 +2,7 @@
 import { TransactionResponse, Provider, TransactionRequest } from '@ethersproject/abstract-provider'
 import { Signer, TypedDataDomain, TypedDataField, TypedDataSigner } from '@ethersproject/abstract-signer'
 import { Deferrable } from '@ethersproject/properties'
-import { StaticJsonRpcProvider } from '@ethersproject/providers'
+import { JsonRpcSigner, StaticJsonRpcProvider } from '@ethersproject/providers'
 import { keccak256 } from '@ethersproject/solidity'
 import { Bytes, hexlify } from "@ethersproject/bytes";
 import { toUtf8Bytes } from "@ethersproject/strings";
@@ -127,7 +127,9 @@ class AvoSigner extends Signer implements TypedDataSigner {
         domain,
         types,
         value
-      })
+      },
+      this.signer as JsonRpcSigner
+    )
 
     if (!result.signature) {
       throw Error("Failed to get signature");

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -121,15 +121,21 @@ class AvoSigner extends Signer implements TypedDataSigner {
   }
 
   async _signTypedData(domain: TypedDataDomain, types: Record<string, TypedDataField[]>, value: Record<string, any>): Promise<string> {
+    if("privateKey" in this.signer) {
+      return await (this.signer as Signer as JsonRpcSigner)._signTypedData(
+        domain,
+        types,
+        value
+      );
+    }
+
     const result = await signTypedData(this.signer.provider as any,
       await this.getSignerAddress(),
       {
         domain,
         types,
         value
-      },
-      this.signer as JsonRpcSigner
-    )
+      })
 
     if (!result.signature) {
       throw Error("Failed to get signature");

--- a/src/utils/signTypedData.ts
+++ b/src/utils/signTypedData.ts
@@ -1,5 +1,5 @@
 // https://github.com/enzymefinance/protocol/blob/c9621dd5f8234bd45126772fc626252a38d46eee/packages/ethers/src/utils/signTypedData.ts
-import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
+import { JsonRpcProvider } from '@ethersproject/providers';
 import { hexlify } from '@ethersproject/bytes';
 import { toUtf8Bytes } from '@ethersproject/strings';
 import type { TypedData } from './typedData';
@@ -10,7 +10,6 @@ export async function signTypedData(
   provider: JsonRpcProvider,
   address: string,
   data: TypedData,
-  signer?: JsonRpcSigner
 ): Promise<{ signature?: string; method?: string; cancelled?: boolean }> {
   const message = await getTypedDataMessage(provider, data.domain, data.types, data.value);
 
@@ -44,26 +43,6 @@ export async function signTypedData(
   try {
     const method = 'eth_sign';
     const signature = await provider.send(method, [address.toLowerCase(), hexlify(toUtf8Bytes(message))]);
-
-    return { method, signature };
-  } catch (error) {
-    if (typeof error === 'string' && error.startsWith('Error: Transaction was rejected')) {
-      return { cancelled: true };
-    }
-
-    if(!signer)
-      throw new Error(typeof error === 'string' ? error : 'An error occured.');
-
-  }
-
-  // Fallback if using a signer
-  try {
-    const method = "eth_sign";
-    const signature = await signer._signTypedData(
-      data.domain,
-      data.types,
-      data.value
-    );
 
     return { method, signature };
   } catch (error) {

--- a/src/utils/signTypedData.ts
+++ b/src/utils/signTypedData.ts
@@ -1,5 +1,5 @@
 // https://github.com/enzymefinance/protocol/blob/c9621dd5f8234bd45126772fc626252a38d46eee/packages/ethers/src/utils/signTypedData.ts
-import { JsonRpcProvider } from '@ethersproject/providers';
+import { JsonRpcProvider, JsonRpcSigner } from '@ethersproject/providers';
 import { hexlify } from '@ethersproject/bytes';
 import { toUtf8Bytes } from '@ethersproject/strings';
 import type { TypedData } from './typedData';
@@ -10,6 +10,7 @@ export async function signTypedData(
   provider: JsonRpcProvider,
   address: string,
   data: TypedData,
+  signer?: JsonRpcSigner
 ): Promise<{ signature?: string; method?: string; cancelled?: boolean }> {
   const message = await getTypedDataMessage(provider, data.domain, data.types, data.value);
 
@@ -43,6 +44,26 @@ export async function signTypedData(
   try {
     const method = 'eth_sign';
     const signature = await provider.send(method, [address.toLowerCase(), hexlify(toUtf8Bytes(message))]);
+
+    return { method, signature };
+  } catch (error) {
+    if (typeof error === 'string' && error.startsWith('Error: Transaction was rejected')) {
+      return { cancelled: true };
+    }
+
+    if(!signer)
+      throw new Error(typeof error === 'string' ? error : 'An error occured.');
+
+  }
+
+  // Fallback if using a signer
+  try {
+    const method = "eth_sign";
+    const signature = await signer._signTypedData(
+      data.domain,
+      data.types,
+      data.value
+    );
 
     return { method, signature };
   } catch (error) {


### PR DESCRIPTION
Closes #11 by adding the ability to pass a `signer` object when calling `signTypedData`; allows to use a `Wallet` object to interact with Avocado.